### PR TITLE
Fix issue #24 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ build/assemble/main.o: src/assembler/main.c ${GLOBAL_DEPS}
 clean: clear
 
 clear:
-	rm -f *.obj *.bin disassembled.asm file.txt vm vmasm disasm build/vm/*.o build/disassemble/*.o build/assemble/*.o
+	rm -f *.obj *.bin disassembled.asm file.txt index.html vm vmasm disasm build/vm/*.o build/disassemble/*.o build/assemble/*.o

--- a/example_programs/array.asm
+++ b/example_programs/array.asm
@@ -1,4 +1,4 @@
-toggle_verbose false
+toggle_verbose 0
 mov 8, $8
 
 mov @scores, $1

--- a/example_programs/html_gen.asm
+++ b/example_programs/html_gen.asm
@@ -1,0 +1,226 @@
+toggle_verbose 0
+jmp .start
+
+# arg_a = message, arg_b = fd
+func_print:
+    ld $arg_a, $arg_c
+    strlen_r $arg_c, $arg_d
+    mov write_syscall, $arg_a
+
+    syscall
+
+ret
+
+# $11 = readinput(stdin, 1024)
+func_readinput:
+    ld $heap, $11
+
+    
+    mov read_syscall, $arg_a
+    mov stdin, $arg_b
+    ld $heap, $arg_c
+    mov 1024, $arg_d
+    syscall
+
+    mov 0, $9
+    ldxo $11, $9, $15
+    # store the first character of the read string to $15
+
+
+ret
+
+func_prompt:
+    mov stdout, $arg_b
+    call .func_print
+
+ret
+
+func_to_html:
+    call .func_readinput
+    ld $11, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+    mov @newline, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+ret
+    
+func_make_page_header:
+    mov @page_header, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+    mov @newline, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+ret
+
+func_start_body:
+    mov @page_start_body, $arg_a
+    ld $10, $arg_b
+    call .func_print
+    
+ret
+
+func_end_body:
+    mov @page_end_body, $arg_a
+    ld $10, $arg_b
+    call .func_print
+ret
+
+func_make_title:
+
+    mov @page_h1_tag_start, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+    mov @enter_title, $arg_a
+    call .func_prompt
+    call .func_to_html
+
+    mov @page_h1_tag_end, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+ret
+
+func_make_subtitle:
+    mov @page_h2_tag_start, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+
+    mov @enter_subtitle, $arg_a
+    call .func_prompt
+    call .func_to_html
+
+    mov @page_h2_tag_end, $arg_a
+    ld $10, $arg_b
+    call .func_print
+
+ret
+
+func_make_line:
+    call .func_to_html
+ret
+
+func_make_linebreak:
+    mov @page_br_tag, $arg_a
+    ld $10, $arg_b
+    call .func_print
+ret
+
+
+start:
+# open file
+mov open_syscall, $arg_a
+mov @filename, $arg_b
+mov O_RDWR, $0
+mov O_CREAT, $1
+mov O_TRUNC, $2
+or $0, $1
+or $0, $2
+ld $0, $arg_c
+mov perm_0644, $arg_d
+syscall
+ld $arg_a, $10          # $10 = FD
+
+call .func_make_page_header
+
+call .func_start_body
+
+    call .func_make_title
+    call .func_make_subtitle
+
+
+    mov @enter_maintext, $arg_a
+    mov stdout, $arg_b
+    call .func_print
+
+    page_readloop:
+
+        call .func_make_line
+        mov 126, $5
+        cmp, $5, $15
+        #print_char $15
+        #line_br
+        #print_int $15
+        call .func_make_linebreak
+        jne .page_readloop
+    
+
+call .func_end_body
+mov @page_endpage, $arg_a
+ld $10, $arg_b
+call .func_print
+
+# close FD
+mov close_syscall, $arg_a
+ld $10, $arg_b
+syscall
+
+halt
+
+.data
+    filename: "index.html"
+    newline: 10 0
+
+    empty: ""
+
+    enter_title: "Page Title: "
+    enter_subtitle: "Subtitle: "
+enter_maintext: 
+"
+Enter a line to the page (Enter a '~' to finish the page): 
+"
+
+page_header: 
+"
+<!DOCTYPE html> 
+<head> 
+<title>Generated Page</title>
+</head>
+"
+
+page_start_body:
+"
+<body>
+"
+
+page_end_body: 
+"
+</body>
+"
+
+page_endpage: 
+"
+</html>
+"
+
+page_h1_tag_start: 
+"
+<h1>
+"
+page_h1_tag_end:   
+"
+</h1>
+"
+
+page_h2_tag_start:
+"
+<h2>
+"
+
+page_h2_tag_end:
+"
+</h2>
+"
+
+page_br_tag:
+"
+<br>
+"
+    

--- a/example_programs/ldo_ldxo_rom_ram.asm
+++ b/example_programs/ldo_ldxo_rom_ram.asm
@@ -1,0 +1,28 @@
+toggle_verbose 1
+
+ldo @another_label, $1
+print_int $1
+line_br
+
+no_op
+
+
+ld $heap, $11
+mov read_syscall, $arg_a
+mov stdin, $arg_b
+ld $heap, $arg_c
+mov 1024, $arg_d
+syscall
+
+mov 0, $0
+
+ldxo $11, $0, $1
+print_char $1
+line_br
+
+halt
+
+
+.data
+    rom_value: 10 20 30
+    another_label: 40, 50, 60

--- a/src/vm/opcodes.c
+++ b/src/vm/opcodes.c
@@ -29,38 +29,35 @@ void vm_verbose_(VM *vm, const char *format, ...) {
 
 #define vm_verbose(fmt, ...) vm_verbose_(vm, (fmt), ##__VA_ARGS__)
 
-static i32 *get_mem_ptr(VM *vm, i32 virtual_addr) {
 
-    if (virtual_addr < 0) return NULL;
-
-    if (virtual_addr < MAX_PROGRAM_SIZE) {
-        return &vm->program[virtual_addr];
-    } else {
-        i32 ram_addr = virtual_addr - MAX_PROGRAM_SIZE;
-
-        if(ram_addr < MAX_PROGRAM_SIZE) {
-            return &vm->memory[ram_addr];
-        }
-    }
-    return NULL;
-}
+struct vm_ptr_info_t {
+    bool RAM_addr;
+    bool ROM_addr;
+    i32 addr;
+} vm_ptr_info;
 
 static i32 *get_vm_ptr(VM *vm, i32 addr) {
+    
+    vm_ptr_info = (struct vm_ptr_info_t){0};
+
     if (addr < 0) return NULL;
 
-    if (addr < MAX_STACK_SIZE) {
+    if (addr < MAX_PROGRAM_SIZE) {
+        vm_ptr_info.ROM_addr = true;
+        vm_ptr_info.addr = addr;
         return &vm->program[addr];
     }
 
     i32 ram_idx = addr - MAX_PROGRAM_SIZE;
     if(ram_idx < MAX_PROGRAM_SIZE) {
+        vm_ptr_info.RAM_addr = true;
+        vm_ptr_info.addr = ram_idx;
         return &vm->memory[ram_idx];
     }
 
     return NULL;
 
 }
-
 
 void no_op(VM *vm) {
     vm_verbose("NO_OP\n");
@@ -83,7 +80,7 @@ void state_dump(VM *vm) {
     }
     printf("##############################\n");
     printf("MACHINE INFO:\n");
-    printf("        program_couter  = %d\n", vm->program_counter);
+    printf("        program_counter  = %d\n", vm->program_counter);
     printf("        program_size    = %d\n", vm->program_size);
     printf("        stack_head      = %d\n", vm->stack_head);
     printf("        top of stack    = %d\n", vm->stack[vm->stack_head - 1]);
@@ -287,7 +284,7 @@ void jmp(VM *vm) {
     vm_verbose("JMP: {");
     vm->program_counter++;
     i32 jmp_to = vm->program[vm->program_counter];
-    vm_verbose(" program_couter -> %.2d }\n", jmp_to);
+    vm_verbose(" program_counter -> %.2d }\n", jmp_to);
     vm->program_counter = jmp_to;
 }
 
@@ -526,14 +523,14 @@ void call(VM *vm) {
     vm->return_address_head++;
 
     i32 jmp_to = vm->program[vm->program_counter];
-    vm_verbose(" program_couter -> %.2d }\n", jmp_to);
+    vm_verbose(" program_counter -> %.2d }\n", jmp_to);
     vm->program_counter = jmp_to;
 }
 
 void ret(VM *vm) {
     vm_verbose("RET: {");
 
-    vm_verbose(" program_couter = %d }\n", vm->return_address_stack[vm->return_address_head - 1]);
+    vm_verbose(" program_counter = %d }\n", vm->return_address_stack[vm->return_address_head - 1]);
     vm->program_counter = vm->return_address_stack[vm->return_address_head - 1];
 
     vm->return_address_head--;
@@ -555,7 +552,7 @@ void syscall_(VM *vm) {
             vm_verbose(" write(%d, 0x%x, %d)", fd, buff_addr, count);
 
             for(i32 i = 0; i < count; ++i) {
-                i32 *ptr = get_mem_ptr(vm, buff_addr + i);
+                i32 *ptr = get_vm_ptr(vm, buff_addr + i);
                 if(ptr) {
                     char c = (char)(*ptr & 0xFF);
                     write(fd, &c, 1);
@@ -781,17 +778,27 @@ void ldo(VM *vm) {
     vm_verbose("LDO: {");
     vm->program_counter++;
 
-    i32 data_addr = vm->program[vm->program_counter];
-    vm_verbose(" @addr=%d", data_addr);
+    i32 *data_addr = get_vm_ptr(vm, vm->program[vm->program_counter]);
+
+    if(vm_ptr_info.ROM_addr) {
+        vm_verbose(" @addr=%d(ROM)", vm_ptr_info.addr);
+    }
+
+    if(vm_ptr_info.RAM_addr) {
+        vm_verbose(" @addr=%d(RAM)", vm_ptr_info.addr);
+    }
 
     vm->program_counter++;
     i32 dest_reg = vm->program[vm->program_counter];
     vm_verbose(" -> $%d", dest_reg);
 
 
-    i32 value = vm->program[data_addr];
+    //i32 value = vm->program[data_addr];
+
+    i32 value = *data_addr;
+
     vm->registers[dest_reg] = value;
-    vm_verbose(" (value=%d) }\n");
+    vm_verbose(" (value=%d) }\n", value);
 
     vm->program_counter++;
 }
@@ -802,23 +809,35 @@ void ldxo(VM *vm) {
 
     i32 base_reg_idx = vm->program[vm->program_counter];
     i32 base_addr = vm->registers[base_reg_idx];
-    vm_verbose(" base$%d(0x%x)", base_reg_idx, base_addr);
+
+    //i32 *base_addr_value = get_vm_ptr(vm, base_addr);
 
     vm->program_counter++;
     i32 index_reg_idx = vm->program[vm->program_counter];
     i32 index_offset = vm->registers[index_reg_idx];
-    vm_verbose(" + $%d(offset=%d)", index_reg_idx, index_offset);
 
     vm->program_counter++;
     i32 dest_reg = vm->program[vm->program_counter];
+
+
+    i32 *final_addr = get_vm_ptr(vm, base_addr + index_offset);
+
+    if(vm_ptr_info.ROM_addr) {
+        vm_verbose(" base$%d(%d)(ROM)", base_reg_idx, base_addr);
+    }
+
+    if(vm_ptr_info.RAM_addr) {
+        vm_verbose(" base$%d(%d)(RAM)", base_reg_idx, base_addr);
+    }
+
+
+    vm_verbose(" + $%d(offset=%d)", index_reg_idx, index_offset);
     vm_verbose(" -> $%d", dest_reg);
 
-    i32 final_addr = base_addr + index_offset;
-
     
-    i32 value = vm->program[final_addr];
+    i32 value = *final_addr;
     vm->registers[dest_reg] = value;
-    vm_verbose(" (value=%d) }\n");
+    vm_verbose(" (value=%d) }\n", value);
 
     vm->program_counter++;
 }


### PR DESCRIPTION
RAM addresses support for LDO and LDXO opcodes
fixes some types related to program counter in verbose output

  - 2 examples:
    -> html_gen.asm -> simple page generator
    -> ldo_ldxo_rom_ram.asm -> testing the new functionality of ldo and ldxo accessing ram addresses


Somehow i made a commit without changes lmao